### PR TITLE
Added Buffer Manager to keep track of logger instances

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.30)
-project(ModularCpp)
+project(cpp-logger)
 include_directories(logger)
 set(CMAKE_CXX_STANDARD 20)
-add_executable(ModularCpp main.cpp
-        logger/logger.h)
+add_executable(cpplogger main.cpp
+        logger/logger.h
+        logger/manager.h)

--- a/logger/logger.h
+++ b/logger/logger.h
@@ -112,6 +112,16 @@ public:
         return this->log_file.is_open();
     }
 
+    // Get the root dir of the logger
+    std::string get_root_dir() const {
+        return this->root_dir;
+    }
+
+    // Get the file name of logger
+    std::string get_file_name() const {
+        return this->file_name;
+    }
+
     // Get the time of when logger started
     std::chrono::system_clock::time_point get_start_time() const {
         return this->start_time;

--- a/logger/logger.h
+++ b/logger/logger.h
@@ -6,6 +6,7 @@
 #include <sys/stat.h>
 #include <fstream>
 #include <chrono>
+#include <manager.h>
 #include <map>
 
 // Logger namespace with utilities
@@ -105,6 +106,9 @@ public:
         // update the status of logger
         this->log_file << ">>> Logger initiated at " << std::chrono::system_clock::now() << " <<<\n";
         std::cout << LOGGER::COLOR::CYAN << ">>> Logger initiated at " << std::chrono::system_clock::now() << " <<<" << LOGGER::COLOR::RESET << "\n";
+
+        // Register the logger to manager buffer
+        BUF_MANAGER<Logger>::register_buf(this);
     }
 
     // Check if the logger is active or running
@@ -177,6 +181,7 @@ public:
         this->end_time = std::chrono::system_clock::now();
         this->log_file << ">>> Logger exited at " << this->end_time << " <<<\n";
         this->log_file.close();
+        BUF_MANAGER<Logger>::unregister_buf(this);       // Unregister the logger from buffer manager
         std::cout << LOGGER::COLOR::CYAN << ">>> Exited Logger at " << this->end_time << " <<<" << LOGGER::COLOR::RESET << "\n";
     }
 

--- a/logger/manager.h
+++ b/logger/manager.h
@@ -1,0 +1,51 @@
+#ifndef MANAGER_H
+#define MANAGER_H
+
+#include <unordered_set>
+
+template <typename T>
+class BUF_MANAGER {
+protected:
+    // All instance buffers would be registered here
+    // for the same runtime
+    static std::string TAG;
+    static inline std::unordered_set<T*> BUFFERS;
+
+public:
+    BUF_MANAGER() {
+        // Initialize the buffer for current runtime
+        TAG = "[BUF_MANAGER]";
+        BUFFERS = std::unordered_set<T*>();
+    }
+
+    ~BUF_MANAGER() {
+        // Clear all the buffers before runtime exit
+        // to avoid memory overflow
+        BUFFERS.clear();
+    }
+
+    // Register a new buffer for the current runtime
+    static bool register_buf(T* buffer) {
+        // Register the new buffer to manager
+        BUFFERS.insert(buffer);
+        return BUFFERS.contains(buffer);
+    }
+
+    // Unregister an existing registered buffer
+    static bool unregister_buf(T* buffer) {
+        BUFFERS.erase(buffer);              // remove an existing buffers from the register
+        return !BUFFERS.contains(buffer);   // check if the register was removed successfully
+    }
+
+    // Get all the existing buffers in the register
+    static std::unordered_set<T*> get_buffs() {
+        return BUFFERS;
+    }
+
+    // Get the total number of registered buffers in the register
+    static int buf_size() {
+        return BUFFERS.size();
+    }
+};
+
+#endif //MANAGER_H


### PR DESCRIPTION
Keep track of all actively running loggers through buffers and kill all of them at once